### PR TITLE
Use unicode data type for the input text

### DIFF
--- a/frog_wrapper.pyx
+++ b/frog_wrapper.pyx
@@ -145,11 +145,11 @@ cdef class Frog:
         self.capi = new frog_classes.FrogAPI(options.capi, self.configuration, &self.logstream)
 
 
-    def process_raw(self, str text):
+    def process_raw(self, text):
         """Invokes Frog on the specified text, the text is considered one document. The raw results from Frog are return as a string"""
         #cdef libfolia_classes.Document * doc = self.capi.tokenizer.tokenizehelper( text.encode('utf-8') )
-        cdef string result = self.capi.Frogtostring(text.encode('utf-8'))
-        r = result.decode('utf-8')
+        cdef string result = self.capi.Frogtostring(self._encode_text(text))
+        r = result.decode('utf-8') if type(text) == unicode else result
         return r
 
     def parsecolumns(self, str response):
@@ -190,4 +190,9 @@ cdef class Frog:
 
     def __del__(self):
         del self.capi
+
+    def _encode_text(self, text):
+        if type(text) == unicode:
+            return text.encode('utf-8')
+        return text
 


### PR DESCRIPTION
Hi,

We're trying to use python-frog @wizenoze and stumbled upon the following error.

When the input text contains some special characters, like the quotation mark below, encode() fails in frog_wrapper.pyx.

```
#!/usr/bin/python
# -*- coding: utf-8 -*-
from frog import Frog, FrogOptions
frog = Frog(FrogOptions(parser=False), '/usr/local/etc/frog/frog.cfg')
text = "‘Probeer"
print type(text)
output = frog.process_raw(text)
```

Error message:

```
20151209:175605:031:Initialization done.
<type 'str'>
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    output = frog.process_raw(text)
  File "frog_wrapper.pyx", line 151, in frog.Frog.process_raw (frog_wrapper.cpp:2898)
    cdef string result = self.capi.Frogtostring(text.encode('utf-8'))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)
```

I'd like to propose to use _unicode_ as the incoming data type for _text_.

After applying this change, the following piece of code is able to run successfully and gives the following output.

```
#!/usr/bin/python
# -*- coding: utf-8 -*-
from frog import Frog, FrogOptions
frog = Frog(FrogOptions(parser=False), '/usr/local/etc/frog/frog.cfg')
text = u"‘Probeer"
print type(text)
output = frog.process_raw(text)
print output
```

Output:

```
20151209:180100:150:Initialization done.
<type 'unicode'>
1   ‘ '   ['] LET()   1.000000    O   B-NP        
2   Probeer proberen    [probeer]   WW(pv,tgw,ev)   0.993151    O   B-VP    
```

Please let me know what do you think about this change?

Thanks for reviewing!

Cheers,
László
